### PR TITLE
fix: disallow extra properties in rule options

### DIFF
--- a/.changeset/quiet-plums-visit.md
+++ b/.changeset/quiet-plums-visit.md
@@ -1,0 +1,5 @@
+---
+"eslint-plugin-markdown-links": patch
+---
+
+fix: disallow extra properties in rule options

--- a/src/rules/no-missing-fragments.ts
+++ b/src/rules/no-missing-fragments.ts
@@ -60,6 +60,7 @@ export default createRule<
             enum: ["github", "mdit-vue"],
           },
         },
+        additionalProperties: false,
       },
     ],
     messages: {

--- a/src/rules/no-missing-path.ts
+++ b/src/rules/no-missing-path.ts
@@ -243,8 +243,10 @@ export default createRule<
                 enum: ["github", "mdit-vue"],
               },
             },
+            additionalProperties: false,
           },
         },
+        additionalProperties: false,
       },
     ],
     messages: {


### PR DESCRIPTION
Some rules, for example [no-missing-fragments](https://github.com/ota-meshi/eslint-plugin-markdown-links/blob/b421287f589a553df840315907e53e05cb59324c/src/rules/no-missing-fragments.ts#L54) currently allow extra properties to be passed in options object, which should not be allowed. This makes it easier for typos in rule options to go unnoticed.

This PR simply disallows extra properties in rules' schemas which currently allow them.