### PR TITLE
fix: handle URL-encoded paths and anchors in markdown link rules

### DIFF
--- a/.changeset/fuzzy-paths-jump.md
+++ b/.changeset/fuzzy-paths-jump.md
@@ -1,0 +1,5 @@
+---
+"eslint-plugin-markdown-links": patch
+---
+
+Fix `markdown-links/no-missing-path` to resolve URL-encoded local file paths and anchor fragments.

--- a/.changeset/quiet-anchors-smile.md
+++ b/.changeset/quiet-anchors-smile.md
@@ -1,0 +1,5 @@
+---
+"eslint-plugin-markdown-links": patch
+---
+
+Fix `markdown-links/no-missing-fragments` to resolve URL-encoded anchor fragments.

--- a/src/rules/no-missing-fragments.ts
+++ b/src/rules/no-missing-fragments.ts
@@ -11,6 +11,7 @@ import type {
 import { iterateAttrs, iterateHTMLTokens } from "../utils/html.ts";
 import type { Slugify } from "../utils/slug.ts";
 import { createSlugify } from "../utils/slug.ts";
+import { decodeURIComponentSafe } from "../utils/url.ts";
 
 type RawFragmentMdHeading = { type: "md-heading"; value: string };
 type RawFragmentHTMLId = { type: "id"; value: string };
@@ -100,6 +101,7 @@ export default createRule<
             }
             return raw.value; // type === 'id'
           })
+          .map((fragment) => decodeURIComponentSafe(fragment))
           .map((fragment) => (ignoreCase ? fragment.toLowerCase() : fragment)),
       );
       for (const node of nodes) {
@@ -107,9 +109,10 @@ export default createRule<
         const fragment = url.slice(1); // Remove the # prefix
         if (!fragment) continue; // Empty fragment
 
+        const decodedFragment = decodeURIComponentSafe(fragment);
         const normalizedFragment = ignoreCase
-          ? fragment.toLowerCase()
-          : fragment;
+          ? decodedFragment.toLowerCase()
+          : decodedFragment;
         if (availableFragments.has(normalizedFragment)) continue;
 
         context.report({

--- a/src/rules/no-missing-path.ts
+++ b/src/rules/no-missing-path.ts
@@ -10,6 +10,7 @@ import { iterateAttrs, iterateHTMLTokens } from "../utils/html.ts";
 import { LRUCache } from "../utils/lru-cache.ts";
 import type { Slugify } from "../utils/slug.ts";
 import { createSlugify, type SlugifyKind } from "../utils/slug.ts";
+import { decodeURIComponentSafe } from "../utils/url.ts";
 
 type AnchorOption = {
   ignoreCase: boolean;
@@ -98,6 +99,7 @@ abstract class AbsFragments implements Fragments {
       } else {
         targetFragment = rawFragment.value;
       }
+      targetFragment = decodeURIComponentSafe(targetFragment);
       return options.ignoreCase ? targetFragment.toLowerCase() : targetFragment;
     }
 
@@ -304,17 +306,18 @@ export default createRule<
      * Get the absolute path of a link or image.
      */
     function getLinkFullPath(fileUrl: string): string {
-      if (fileUrl.startsWith("/")) {
+      const decodedFileUrl = decodeURIComponentSafe(fileUrl);
+      if (decodedFileUrl.startsWith("/")) {
         // - [a](/foo.md)
-        return path.join(basePath, fileUrl.slice(1));
+        return path.join(basePath, decodedFileUrl.slice(1));
       }
-      if (fileUrl.startsWith("./") || fileUrl.startsWith("../")) {
+      if (decodedFileUrl.startsWith("./") || decodedFileUrl.startsWith("../")) {
         // - [a](./foo.md)
-        return path.join(dirname, fileUrl);
+        return path.join(dirname, decodedFileUrl);
       }
 
       // - [a](foo.md)
-      return path.join(dirname, fileUrl);
+      return path.join(dirname, decodedFileUrl);
     }
 
     /**
@@ -377,11 +380,13 @@ export default createRule<
       reportNode: Link | Image | Definition,
       resolved: LinkPathWithFragment,
     ) {
-      if (RE_GITHUB_LINE_REFERENCE_FRAGMENT.test(resolved.fragment)) return;
+      const fragment = decodeURIComponentSafe(resolved.fragment);
+      if (RE_GITHUB_LINE_REFERENCE_FRAGMENT.test(fragment)) return;
       if (
         anchorAllowlist.some(([url, anchor]) => {
           return (
-            url.test(resolved.relativePath) && anchor.test(resolved.fragment)
+            url.test(resolved.relativePath) &&
+            (anchor.test(resolved.fragment) || anchor.test(fragment))
           );
         })
       )
@@ -406,7 +411,7 @@ export default createRule<
 
       const checker = fragments.fragmentChecker(anchorOption);
 
-      if (checker(resolved.fragment)) {
+      if (checker(fragment)) {
         return;
       }
 

--- a/src/utils/url.ts
+++ b/src/utils/url.ts
@@ -1,0 +1,10 @@
+/**
+ * Decode a percent-encoded URI component without throwing on malformed input.
+ */
+export function decodeURIComponentSafe(value: string): string {
+  try {
+    return decodeURIComponent(value);
+  } catch {
+    return value;
+  }
+}

--- a/tests/fixtures/rules/no-missing-fragments/invalid/missing-fragments-input.md
+++ b/tests/fixtures/rules/no-missing-fragments/invalid/missing-fragments-input.md
@@ -11,3 +11,7 @@ This is an invalid reference to [non-existent section](#non-existent-section).
 Another invalid reference to [missing fragment](#missing-fragment).
 
 Also invalid: [wrong name](#wrong-name).
+
+## Encoded Hash {#%23anchor}
+
+This should not match [decoded custom id](#anchor).

--- a/tests/fixtures/rules/no-missing-fragments/valid/basic-heading-input.md
+++ b/tests/fixtures/rules/no-missing-fragments/valid/basic-heading-input.md
@@ -17,3 +17,7 @@ You can also reference [this subsection](#subsection).
 ## Code Examples
 
 Reference to the [code examples](#code-examples) section.
+
+## 日本語
+
+Reference to the [Japanese heading](#%E6%97%A5%E6%9C%AC%E8%AA%9E) section.

--- a/tests/fixtures/rules/no-missing-fragments/valid/html-id-input.md
+++ b/tests/fixtures/rules/no-missing-fragments/valid/html-id-input.md
@@ -10,6 +10,10 @@ This is a valid reference to the [custom section](#custom-section).
 
 Reference to [inline element](#inline-element).
 
+<span id="%E6%97%A5%E6%9C%AC%E8%AA%9E">Encoded Id</span>
+
+Reference to [encoded id](#%E6%97%A5%E6%9C%AC%E8%AA%9E).
+
 ## Regular Heading
 
 And a [regular heading](#regular-heading) reference.

--- a/tests/fixtures/rules/no-missing-path/invalid/basic-input.md
+++ b/tests/fixtures/rules/no-missing-path/invalid/basic-input.md
@@ -26,6 +26,7 @@
 
 - [missing-anchor](target.md#not-exist-anchor)
 - [missing-anchor](../test-target.md#not-exist-anchor)
+- [missing-anchor](../test-target.md#anchor)
 
 # Valid: HTML Reference Non-existent Anchor
 

--- a/tests/fixtures/rules/no-missing-path/test-target.md
+++ b/tests/fixtures/rules/no-missing-path/test-target.md
@@ -12,6 +12,14 @@ Contents
 
 </div>
 
+<div id="%E3%83%86%E3%82%B9%E3%83%88">
+
+Encoded id contents
+
+</div>
+
+## Encoded Hash Custom Id {#%23anchor}
+
 ## 日本語
 
 ## H<span>T</span>Ml

--- a/tests/fixtures/rules/no-missing-path/valid/File With Space.md
+++ b/tests/fixtures/rules/no-missing-path/valid/File With Space.md
@@ -1,0 +1,3 @@
+# Section
+
+This file name contains spaces.

--- a/tests/fixtures/rules/no-missing-path/valid/allowed-anchors/_config.json
+++ b/tests/fixtures/rules/no-missing-path/valid/allowed-anchors/_config.json
@@ -2,7 +2,7 @@
   "options": [
     {
       "allowedAnchors": {
-        "/\\/test-target.md$/iu": "/^custom-anchor$/iu"
+        "/\\/test-target.md$/iu": "/^(?:custom-anchor|%E6%97%A5%E6%9C%AC%E8%AA%9E-missing)$/iu"
       }
     }
   ]

--- a/tests/fixtures/rules/no-missing-path/valid/allowed-anchors/allowed-anchor-input.md
+++ b/tests/fixtures/rules/no-missing-path/valid/allowed-anchors/allowed-anchor-input.md
@@ -1,3 +1,4 @@
 # Allowed Anchor Test
 
 - [custom](../../test-target.md#custom-anchor)
+- [encoded](../../test-target.md#%E6%97%A5%E6%9C%AC%E8%AA%9E-missing)

--- a/tests/fixtures/rules/no-missing-path/valid/basic-input.md
+++ b/tests/fixtures/rules/no-missing-path/valid/basic-input.md
@@ -5,12 +5,31 @@
 - [target](../test-target.md)
 - [target](/tests/fixtures/rules/no-missing-path/test-target.md)
 
+# Valid: Url-encoded Existing Path
+
+- [target](File%20With%20Space.md)
+- [target](File%20With%20Space.md#section)
+- [target](hash%23target.md)
+- [target](percent%25target.md)
+- [target](%E6%97%A5%E6%9C%AC%E8%AA%9E.md)
+- [target](%E6%97%A5%E6%9C%AC%E8%AA%9E.md#section)
+
+# Valid: Existing Path Without Encoding
+
+- [target](<File With Space.md>)
+- [target](<File With Space.md#section>)
+- [target](percent%target.md)
+- [target](日本語.md)
+- [target](日本語.md#section)
+
 # Valid: Existing Anchor
 
 - [target](../test-target.md#a)
 - [target](../test-target.md#custom-id)
 - [target](../test-target.md#html-id)
+- [target](../test-target.md#%E3%83%86%E3%82%B9%E3%83%88)
 - [target](../test-target.md#日本語)
+- [target](../test-target.md#%E6%97%A5%E6%9C%AC%E8%AA%9E)
 - [target](../test-target.md#html)
 - [target](../test-target.md#dupe)
 - [target](../test-target.md#dupe-1)

--- a/tests/fixtures/rules/no-missing-path/valid/hash#target.md
+++ b/tests/fixtures/rules/no-missing-path/valid/hash#target.md
@@ -1,0 +1,3 @@
+# Hash Target
+
+This file name contains a hash mark.

--- a/tests/fixtures/rules/no-missing-path/valid/percent%target.md
+++ b/tests/fixtures/rules/no-missing-path/valid/percent%target.md
@@ -1,0 +1,3 @@
+# Percent Target
+
+This file name contains a literal percent sign.

--- a/tests/fixtures/rules/no-missing-path/valid/日本語.md
+++ b/tests/fixtures/rules/no-missing-path/valid/日本語.md
@@ -1,0 +1,3 @@
+# Section
+
+This file name contains multibyte characters.

--- a/tests/src/rules/__snapshots__/no-missing-fragments.ts.eslintsnap
+++ b/tests/src/rules/__snapshots__/no-missing-fragments.ts.eslintsnap
@@ -56,10 +56,16 @@ Code:
  13 | Also invalid: [wrong name](#wrong-name).
     |               ^~~~~~~~~~~~~~~~~~~~~~~~~ [3]
  14 |
+ 15 | ## Encoded Hash {#%23anchor}
+ 16 |
+ 17 | This should not match [decoded custom id](#anchor).
+    |                       ^~~~~~~~~~~~~~~~~~~~~~~~~~~~ [4]
+ 18 |
 
 [1] The fragment 'non-existent-section' is not defined in this file.
 [2] The fragment 'missing-fragment' is not defined in this file.
 [3] The fragment 'wrong-name' is not defined in this file.
+[4] The fragment 'anchor' is not defined in this file.
 ---
 
 

--- a/tests/src/rules/__snapshots__/no-missing-path.ts.eslintsnap
+++ b/tests/src/rules/__snapshots__/no-missing-path.ts.eslintsnap
@@ -177,38 +177,40 @@ Code:
     |   ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ [7]
  28 | - [missing-anchor](../test-target.md#not-exist-anchor)
     |   ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ [8]
- 29 |
- 30 | # Valid: HTML Reference Non-existent Anchor
- 31 |
- 32 | - [target](../test-target.html#not-exist-anchor)
-    |   ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ [9]
- 33 |
- 34 | # Valid: Existing Path
- 35 |
- 36 | - [target](target.md)
- 37 | - [target](./target.md)
- 38 | - [target](../test-target.md)
- 39 |
- 40 | # Valid: Existing Anchor
- 41 |
- 42 | - [target](../test-target.md#a)
- 43 | - [target](../test-target.md#custom-id)
- 44 |
- 45 | # Valid: External Link
- 46 |
- 47 | - [external](https://example.com)
- 48 |
- 49 | # Valid: Anchor Only
- 50 |
- 51 | - [anchor](#section)
- 52 |
- 53 | # Invalid: Non-existent Path (Definition)
- 54 |
- 55 | - [notfound]
- 56 |
- 57 | [notfound]: not-found.md
-    | ^~~~~~~~~~~~~~~~~~~~~~~~ [10]
- 58 |
+ 29 | - [missing-anchor](../test-target.md#anchor)
+    |   ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ [9]
+ 30 |
+ 31 | # Valid: HTML Reference Non-existent Anchor
+ 32 |
+ 33 | - [target](../test-target.html#not-exist-anchor)
+    |   ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ [10]
+ 34 |
+ 35 | # Valid: Existing Path
+ 36 |
+ 37 | - [target](target.md)
+ 38 | - [target](./target.md)
+ 39 | - [target](../test-target.md)
+ 40 |
+ 41 | # Valid: Existing Anchor
+ 42 |
+ 43 | - [target](../test-target.md#a)
+ 44 | - [target](../test-target.md#custom-id)
+ 45 |
+ 46 | # Valid: External Link
+ 47 |
+ 48 | - [external](https://example.com)
+ 49 |
+ 50 | # Valid: Anchor Only
+ 51 |
+ 52 | - [anchor](#section)
+ 53 |
+ 54 | # Invalid: Non-existent Path (Definition)
+ 55 |
+ 56 | - [notfound]
+ 57 |
+ 58 | [notfound]: not-found.md
+    | ^~~~~~~~~~~~~~~~~~~~~~~~ [11]
+ 59 |
 
 [1] The file 'notfound.md' does not exist. Please check the path or update it to a valid file.
 [2] The file './notfound.md' does not exist. Please check the path or update it to a valid file.
@@ -218,8 +220,9 @@ Code:
 [6] The file 'notfound.md#anchor' does not exist. Please check the path or update it to a valid file.
 [7] The anchor 'not-exist-anchor' is not defined in 'tests/fixtures/rules/no-missing-path/invalid/target.md'.
 [8] The anchor 'not-exist-anchor' is not defined in 'tests/fixtures/rules/no-missing-path/test-target.md'.
-[9] The anchor 'not-exist-anchor' is not defined in 'tests/fixtures/rules/no-missing-path/test-target.html'.
-[10] The file 'not-found.md' does not exist. Please check the path or update it to a valid file.
+[9] The anchor 'anchor' is not defined in 'tests/fixtures/rules/no-missing-path/test-target.md'.
+[10] The anchor 'not-exist-anchor' is not defined in 'tests/fixtures/rules/no-missing-path/test-target.html'.
+[11] The file 'not-found.md' does not exist. Please check the path or update it to a valid file.
 ---
 
 


### PR DESCRIPTION
close #121