### PR TITLE
Fix changesets action v2 inputs in release workflow

### DIFF
--- a/.github/workflows/Release.yml
+++ b/.github/workflows/Release.yml
@@ -39,8 +39,8 @@ jobs:
         id: changesets
         uses: changesets/action@v2.0.0
         with:
-          version: npm run changeset:version
-          publish: npm run changeset:publish
+          version-script: npm run changeset:version
+          publish-script: npm run changeset:publish
         env:
           SYNCKIT_TS_RUNNER: oxc
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
`changesets/action@v2` renamed the custom version and publish inputs, but the release workflow still used their v1 names. As a result, the action rejected its configuration in the [failed release run](https://github.com/ota-meshi/eslint-plugin-markdown-links/actions/runs/31652879896) before it could create a release pull request or publish a package.

This updates the two input keys to `version-script` and `publish-script` while preserving the existing release commands and behavior.
